### PR TITLE
[add] library linkage

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -6,6 +6,7 @@ add_qe_library(${target}
 	circuit.cpp
 )
 
+target_link_libraries(${target} PRIVATE math utility)
 
 add_unit_test(${target}_unit_tests
 	SOURCES 

--- a/src/qe-gurobi/CMakeLists.txt
+++ b/src/qe-gurobi/CMakeLists.txt
@@ -5,6 +5,7 @@ add_qe_library(${target}
 	solve.cpp
 )
 target_link_libraries(${target} PUBLIC gurobi_cpp)
+target_link_libraries(${target} PRIVATE base math utility)
 
 add_unit_test(${target}_unit_tests
 	SOURCES 


### PR DESCRIPTION
Link `math` and `utility` to `base` and link `math`, `utility` and `base` to `qe-gurobi`.