### PR TITLE
[fix] change scope keywords from PRIVATE to PUBLIC

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -6,7 +6,7 @@ add_qe_library(${target}
 	circuit.cpp
 )
 
-target_link_libraries(${target} PRIVATE math utility)
+target_link_libraries(${target} PUBLIC math utility)
 
 add_unit_test(${target}_unit_tests
 	SOURCES 

--- a/src/qe-gurobi/CMakeLists.txt
+++ b/src/qe-gurobi/CMakeLists.txt
@@ -5,7 +5,7 @@ add_qe_library(${target}
 	solve.cpp
 )
 target_link_libraries(${target} PUBLIC gurobi_cpp)
-target_link_libraries(${target} PRIVATE base math utility)
+target_link_libraries(${target} PUBLIC base math utility)
 
 add_unit_test(${target}_unit_tests
 	SOURCES 


### PR DESCRIPTION
This allows the linking projects to access the API (header files) of the linked project as well as their implementation.