### PR TITLE
[add] formatters for `Binary`, `BinaryPhase`, `Matrix`

### DIFF
--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -6,11 +6,18 @@ add_qe_library(${target}
 	graph.h
 	graph.cpp
 	matrix.h
+	format_binary.h
+	format_binary_phase.h
+	format_matrix.h
+	format_math.h
 )
 
+target_link_libraries(${target} PUBLIC fmt)
 
 add_unit_test(${target}_unit_tests
 	SOURCES 
+		tests/binary_tests.cpp
+		tests/binary_phase_tests.cpp
 		tests/graph_tests.cpp
 		tests/matrix_tests.cpp
 	DEPENDENCIES

--- a/src/math/binary.h
+++ b/src/math/binary.h
@@ -8,7 +8,7 @@ namespace qe {
 	public:
 		constexpr Binary() = default;
 		explicit(false) constexpr Binary(bool value) : value(value) {};
-		explicit constexpr Binary(int value) : value(!!value) {};
+		explicit constexpr Binary(int value) : value(value & 1) {};
 
 		constexpr Binary& operator+=(const Binary& a) { value ^= a.value; return *this; }
 		constexpr Binary& operator-=(const Binary& a) { return this->operator+=(a); }
@@ -21,10 +21,13 @@ namespace qe {
 		constexpr friend Binary operator&(const Binary& a, const Binary& b) { return Binary{ a } &= b; }
 		constexpr friend Binary operator|(const Binary& a, const Binary& b) { return Binary{ a } |= b; }
 
-		constexpr operator int() const { return value; }
+		explicit constexpr operator int() const { return value; }
+		explicit constexpr operator bool() const { return value == 1; }
 		constexpr int to_int() const { return value; }
-		constexpr Binary& negate() { value = !value; return *this; }
+		constexpr Binary& negate() { value = 1 - value; return *this; }
 		constexpr Binary operator~() const { return Binary{ !value }; }
+
+		constexpr friend bool operator==(const Binary& a, const Binary& b) = default;
 
 	private:
 		int value{};

--- a/src/math/binary_phase.h
+++ b/src/math/binary_phase.h
@@ -1,8 +1,4 @@
-﻿
-#pragma once
-#include <string>
-#include <array>
-
+﻿#pragma once
 
 namespace qe {
 
@@ -21,10 +17,7 @@ namespace qe {
 
 		constexpr BinaryPhase& operator++() { return *this += 1; }
 		constexpr BinaryPhase& operator--() { return *this += 3; }
-		constexpr unsigned int operator()() const { return phase; }
 		constexpr unsigned int to_int() const { return phase; }
-
-		std::string to_string() const { static constexpr std::array<std::string_view, 4> c{ "+","i","-","-i" };  return std::string(c[phase]); }
 
 		constexpr bool is_real() const { return (phase & 1) == 0; }
 		constexpr friend bool operator==(const BinaryPhase& a, const BinaryPhase& b) = default;
@@ -35,5 +28,3 @@ namespace qe {
 	};
 
 }
-
-

--- a/src/math/format_binary.h
+++ b/src/math/format_binary.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "binary.h"
+#include "fmt/core.h"
+
+namespace qe {
+
+constexpr auto format_as(Binary binary) {
+	return binary.to_int();
+}
+
+}

--- a/src/math/format_binary_phase.h
+++ b/src/math/format_binary_phase.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "binary_phase.h"
+#include "fmt/format.h"
+
+namespace qe {
+
+inline auto format_as(BinaryPhase binary_phase) {
+	static constexpr std::string_view values[4] = { "+", "i", "-", "-i" };
+	return values[binary_phase.to_int()];
+}
+
+}

--- a/src/math/format_math.h
+++ b/src/math/format_math.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "format_binary.h"
+#include "format_binary_phase.h"
+#include "format_matrix.h"

--- a/src/math/format_matrix.h
+++ b/src/math/format_matrix.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "matrix.h"
+#include "fmt/format.h"
+
+
+template <class T, int m, int n>
+struct fmt::formatter<qe::Matrix<T, m, n>> : nested_formatter<T> {
+	using Parent = nested_formatter<T>;
+
+	constexpr auto format(const qe::Matrix<T, m, n>& matrix, format_context& ctx) const {
+		auto buffer = std::string{};
+		std::vector<size_t> colWidths(matrix.cols());
+		for (size_t j = 0; j < matrix.cols(); ++j) {
+			colWidths[j] = std::accumulate(
+				matrix.col_begin(j), matrix.col_end(j), 0ULL, [&](const auto& max, const auto& el) {
+					buffer.clear();
+					fmt::format_to(std::back_inserter(buffer), "{}", Parent::nested(el));
+					return std::max(max, buffer.size());
+				});
+		}
+		for (size_t i = 0; i < matrix.rows(); ++i) {
+			std::format_to(ctx.out(), "| ");
+			for (size_t j = 0; j < matrix.cols(); ++j) {
+				buffer.clear();
+				fmt::format_to(std::back_inserter(buffer), "{}", Parent::nested(matrix(i, j)));
+				fmt::format_to(ctx.out(), "{:{}} ", buffer, colWidths[j]);
+			}
+			fmt::format_to(ctx.out(), "|\n");
+		}
+		return ctx.out();
+	}
+};

--- a/src/math/format_matrix.h
+++ b/src/math/format_matrix.h
@@ -8,14 +8,14 @@ template <class T, qe::Index m, qe::Index n>
 struct fmt::formatter<qe::Matrix<T, m, n>> : nested_formatter<T> {
 	using Parent = nested_formatter<T>;
 
-	constexpr auto format(const qe::Matrix<T, m, n>& matrix, format_context& ctx) const {
+	auto format(const qe::Matrix<T, m, n>& matrix, format_context& ctx) const {
 		auto buffer = std::string{};
 		std::vector<size_t> colWidths(matrix.cols());
 		for (size_t j = 0; j < matrix.cols(); ++j) {
 			colWidths[j] = std::accumulate(matrix.col_begin(j), matrix.col_end(j), size_t{ 0 },
 				[&](const auto& max, const auto& el) {
 					buffer.clear();
-					fmt::format_to(std::back_inserter(buffer), "{}", Parent::nested(el));
+					fmt::format_to(std::back_inserter(buffer), "{}", this->nested(el));
 					return std::max(max, buffer.size());
 				});
 		}
@@ -23,7 +23,7 @@ struct fmt::formatter<qe::Matrix<T, m, n>> : nested_formatter<T> {
 			fmt::format_to(ctx.out(), "| ");
 			for (size_t j = 0; j < matrix.cols(); ++j) {
 				buffer.clear();
-				fmt::format_to(std::back_inserter(buffer), "{}", Parent::nested(matrix(i, j)));
+				fmt::format_to(std::back_inserter(buffer), "{}", this->nested(matrix(i, j)));
 				fmt::format_to(ctx.out(), "{:{}} ", buffer, colWidths[j]);
 			}
 			fmt::format_to(ctx.out(), "|\n");

--- a/src/math/format_matrix.h
+++ b/src/math/format_matrix.h
@@ -12,15 +12,15 @@ struct fmt::formatter<qe::Matrix<T, m, n>> : nested_formatter<T> {
 		auto buffer = std::string{};
 		std::vector<size_t> colWidths(matrix.cols());
 		for (size_t j = 0; j < matrix.cols(); ++j) {
-			colWidths[j] = std::accumulate(
-				matrix.col_begin(j), matrix.col_end(j), 0ULL, [&](const auto& max, const auto& el) {
+			colWidths[j] = std::accumulate(matrix.col_begin(j), matrix.col_end(j), size_t{ 0 },
+				[&](const auto& max, const auto& el) {
 					buffer.clear();
 					fmt::format_to(std::back_inserter(buffer), "{}", Parent::nested(el));
 					return std::max(max, buffer.size());
 				});
 		}
 		for (size_t i = 0; i < matrix.rows(); ++i) {
-			std::format_to(ctx.out(), "| ");
+			fmt::format_to(ctx.out(), "| ");
 			for (size_t j = 0; j < matrix.cols(); ++j) {
 				buffer.clear();
 				fmt::format_to(std::back_inserter(buffer), "{}", Parent::nested(matrix(i, j)));

--- a/src/math/format_matrix.h
+++ b/src/math/format_matrix.h
@@ -4,7 +4,7 @@
 #include "fmt/format.h"
 
 
-template <class T, int m, int n>
+template <class T, qe::Index m, qe::Index n>
 struct fmt::formatter<qe::Matrix<T, m, n>> : nested_formatter<T> {
 	using Parent = nested_formatter<T>;
 

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -515,7 +515,7 @@ namespace qe {
 		}
 
 
-		friend std::ostream& operator<<(std::ostream& os, const Matrix& a) {
+	/*	friend std::ostream& operator<<(std::ostream& os, const Matrix& a) {
 			std::vector<size_type> col_widths(a.cols());
 			os << std::setfill(' ');
 			for (size_type j = 0; j < a.cols(); ++j) {
@@ -540,7 +540,7 @@ namespace qe {
 			}
 			os.width(0);
 			return os << "\n";
-		}
+		}*/
 
 
 		//

--- a/src/math/tests/binary_phase_tests.cpp
+++ b/src/math/tests/binary_phase_tests.cpp
@@ -1,0 +1,44 @@
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/catch_approx.hpp"
+
+
+#include "binary_phase.h"
+#include "format_binary_phase.h"
+
+using namespace qe;
+
+
+TEST_CASE("BinaryPhase constructor") {
+	REQUIRE(BinaryPhase{ 0 }.to_int() == 0);
+	REQUIRE(BinaryPhase{ 1 }.to_int() == 1);
+	REQUIRE(BinaryPhase{ 2 }.to_int() == 2);
+	REQUIRE(BinaryPhase{ 3 }.to_int() == 3);
+	REQUIRE(BinaryPhase{ -1 }.to_int() == 3);
+	REQUIRE(BinaryPhase{ 10 }.to_int() == 2);
+}
+
+TEST_CASE("BinaryPhase arithmetic") {
+	REQUIRE(BinaryPhase{ 0 } + BinaryPhase{ 0 } == BinaryPhase{ 0 });
+	REQUIRE(BinaryPhase{ 0 } + BinaryPhase{ 1 } == BinaryPhase{ 1 });
+	REQUIRE(BinaryPhase{ 3 } + BinaryPhase{ 0 } == BinaryPhase{ 3 });
+	REQUIRE(BinaryPhase{ 1 } + BinaryPhase{ 3 } == BinaryPhase{ 0 });
+
+	REQUIRE(++BinaryPhase{ 3 } == BinaryPhase{ 0 });
+	REQUIRE(--BinaryPhase{ 0 } == BinaryPhase{ 3 });
+
+	REQUIRE(BinaryPhase{ 0 }.is_real());
+	REQUIRE(BinaryPhase{ 2 }.is_real());
+	REQUIRE(!BinaryPhase{ 1 }.is_real());
+	REQUIRE(!BinaryPhase{ 3 }.is_real());
+
+	BinaryPhase phase{ 2 };
+	phase += 3;
+	REQUIRE(phase == BinaryPhase{ 1 });
+}
+
+TEST_CASE("Format BinaryPhase") {
+	REQUIRE(fmt::format("{}", BinaryPhase{ 0 }) == "+");
+	REQUIRE(fmt::format("{}", BinaryPhase{ 1 }) == "i");
+	REQUIRE(fmt::format("{}", BinaryPhase{ 2 }) == "-");
+	REQUIRE(fmt::format("{}", BinaryPhase{ 3 }) == "-i");
+}

--- a/src/math/tests/binary_tests.cpp
+++ b/src/math/tests/binary_tests.cpp
@@ -1,0 +1,37 @@
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/catch_approx.hpp"
+
+
+#include "binary.h"
+#include "format_binary.h"
+
+using namespace qe;
+
+
+TEST_CASE("Binary constructor") {
+	REQUIRE(Binary{ 0 }.to_int() == 0);
+	REQUIRE(Binary{ 1 }.to_int() == 1);
+}
+
+TEST_CASE("Binary arithmetic") {
+	REQUIRE(Binary{ 0 } + Binary{ 0 } == Binary{ 0 });
+	REQUIRE(Binary{ 0 } + Binary{ 1 } == Binary{ 1 });
+	REQUIRE(Binary{ 1 } + Binary{ 0 } == Binary{ 1 });
+	REQUIRE(Binary{ 1 } + Binary{ 1 } == Binary{ 0 });
+
+	REQUIRE(Binary{ 0 } * Binary{ 0 } == Binary{ 0 });
+	REQUIRE(Binary{ 0 } * Binary{ 1 } == Binary{ 0 });
+	REQUIRE(Binary{ 1 } * Binary{ 0 } == Binary{ 0 });
+	REQUIRE(Binary{ 1 } * Binary{ 1 } == Binary{ 1 });
+
+	REQUIRE(Binary{ 0 }.negate() == Binary{ 1 });
+	REQUIRE(Binary{ 1 }.negate() == Binary{ 0 });
+
+	REQUIRE(~Binary{ 0 } == Binary{ 1 });
+	REQUIRE(~Binary{ 1 } == Binary{ 0 });
+}
+
+TEST_CASE("Format Binary") {
+	REQUIRE(fmt::format("{}", Binary{ 0 }) == "0");
+	REQUIRE(fmt::format("{}", Binary{ 1 }) == "1");
+}

--- a/src/math/tests/matrix_tests.cpp
+++ b/src/math/tests/matrix_tests.cpp
@@ -1,9 +1,10 @@
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/catch_approx.hpp>
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/catch_approx.hpp"
 
 
 #define MATRIX_EXCEPTIONS
 #include "matrix.h"
+#include "format_matrix.h"
 
 #include <iostream>
 
@@ -11,16 +12,16 @@ using Catch::Approx;
 using namespace qe;
 
 
-template<std::random_access_iterator It>
+template <std::random_access_iterator It>
 void checkRandomAccessIterator(It) {
 }
 
 
-template<std::bidirectional_iterator It>
+template <std::bidirectional_iterator It>
 void checkBirectionalIterator(It) {
 }
 
-template<class T, Index m, Index n>
+template <class T, Index m, Index n>
 void testSizeImpl() {
 	Matrix<float, m, n> mat;
 	REQUIRE(m == mat.rows());
@@ -30,26 +31,26 @@ void testSizeImpl() {
 
 
 TEST_CASE("Dynamic Constructor with deduction guide") {
-	Matrix mat{ 1,2,{4,5,6} };
+	Matrix mat{ 1, 2, { 4, 5, 6 } };
 	static_assert(std::same_as<decltype(mat)::value_type, int>);
 	REQUIRE(mat(0, 0) == 4);
 }
 TEST_CASE("Dynamic Constructor") {
 	SECTION("Dimensions") {
-		Matrix<int> mat{ Shape<false>{3,2} };
+		Matrix<int> mat{ Shape<false>{ 3, 2 } };
 		REQUIRE(mat.rows() == 3);
 		REQUIRE(mat.cols() == 2);
 	}
 
 	SECTION("m,n") {
-		Matrix<int> mat{ 3,2 };
+		Matrix<int> mat{ 3, 2 };
 		REQUIRE(mat.rows() == 3);
 		REQUIRE(mat.cols() == 2);
 	}
 
 
 	SECTION("Value") {
-		Matrix<int> mat{ 3,2,4 };
+		Matrix<int> mat{ 3, 2, 4 };
 		REQUIRE(mat.rows() == 3);
 		REQUIRE(mat.cols() == 2);
 		REQUIRE(mat(0, 0) == 4);
@@ -57,7 +58,7 @@ TEST_CASE("Dynamic Constructor") {
 
 
 	SECTION("Initializer list") {
-		Matrix<int> mat{ 3,2, {3,4,5,6} };
+		Matrix<int> mat{ 3, 2, { 3, 4, 5, 6 } };
 		REQUIRE(mat.rows() == 3);
 		REQUIRE(mat.cols() == 2);
 		REQUIRE(mat(0, 0) == 3);
@@ -71,7 +72,7 @@ TEST_CASE("Dynamic Constructor") {
 
 	SECTION("vector copy") {
 		std::vector<int> data{ 3, 4, 5, 6 };
-		Matrix<int> mat{ 3,2, data };
+		Matrix<int> mat{ 3, 2, data };
 		REQUIRE(mat.rows() == 3);
 		REQUIRE(mat.cols() == 2);
 		REQUIRE(mat(0, 0) == 3);
@@ -84,7 +85,7 @@ TEST_CASE("Dynamic Constructor") {
 
 	SECTION("vector move") {
 		std::vector<int> data{ 3, 4, 5, 6 };
-		Matrix<int> mat{ 3,2,  std::move(data) };
+		Matrix<int> mat{ 3, 2, std::move(data) };
 		REQUIRE(mat.rows() == 3);
 		REQUIRE(mat.cols() == 2);
 		REQUIRE(mat(0, 0) == 3);
@@ -97,7 +98,7 @@ TEST_CASE("Dynamic Constructor") {
 
 
 	SECTION("From Matrix view") {
-		Matrix<int> mat{ 4,5,2 };
+		Matrix<int> mat{ 4, 5, 2 };
 		Matrix mat2 = mat.row(2);
 		REQUIRE(mat2.rows() == 1);
 		REQUIRE(mat2.cols() == 5);
@@ -107,21 +108,19 @@ TEST_CASE("Dynamic Constructor") {
 		REQUIRE(mat(0, 3) == 2);
 		REQUIRE(mat(0, 4) == 2);
 	}
-
 }
 
 
 TEST_CASE("Dynamic arithmetic") {
-	Matrix<int> a{ 2,3 };
-	Matrix<int> b{ 2,3 };
+	Matrix<int> a{ 2, 3 };
+	Matrix<int> b{ 2, 3 };
 	a + b;
 	b.resize(2, 4);
 
 	bool exceptionHappened{ false };
 	try {
 		a + b;
-	}
-	catch (Matrix_shape_error&) {
+	} catch (Matrix_shape_error&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened);
@@ -131,8 +130,7 @@ TEST_CASE("Dynamic arithmetic") {
 	exceptionHappened = false;
 	try {
 		a* b;
-	}
-	catch (Matrix_shape_error&) {
+	} catch (Matrix_shape_error&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened);
@@ -140,22 +138,21 @@ TEST_CASE("Dynamic arithmetic") {
 
 
 TEST_CASE("Dynamic transpose") {
-	Matrix<int> a{ 2,3 };
+	Matrix<int> a{ 2, 3 };
 	a = a.transpose();
 	REQUIRE(a.rows() == 3);
 	REQUIRE(a.cols() == 2);
 }
 
 TEST_CASE("Dynamic dot product") {
-	Matrix<int> a{ 2,1, {3,4} };
-	Matrix<int> b{ 2,1, {6,7} };
+	Matrix<int> a{ 2, 1, { 3, 4 } };
+	Matrix<int> b{ 2, 1, { 6, 7 } };
 	REQUIRE(a.dot(b) == 18 + 28);
 	b.resize(2, 2);
 	bool exceptionHappened{ false };
 	try {
 		a.dot(b);
-	}
-	catch (Matrix_shape_error&) {
+	} catch (Matrix_shape_error&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened);
@@ -164,7 +161,7 @@ TEST_CASE("Dynamic dot product") {
 
 TEST_CASE("Dynamic diag") {
 	SECTION("Vector") {
-		Matrix vec(4, 1, { 3,4,2,1 });
+		Matrix vec(4, 1, { 3, 4, 2, 1 });
 		auto mat = diag(vec);
 		REQUIRE(mat.rows() == 4);
 		REQUIRE(mat.cols() == 4);
@@ -175,7 +172,7 @@ TEST_CASE("Dynamic diag") {
 	}
 
 	SECTION("Initializer list") {
-		auto mat = diag({ 3,4,2,1 });
+		auto mat = diag({ 3, 4, 2, 1 });
 		REQUIRE(mat.rows() == 4);
 		REQUIRE(mat.cols() == 4);
 		REQUIRE(mat(0, 0) == 3);
@@ -188,7 +185,7 @@ TEST_CASE("Dynamic diag") {
 
 TEST_CASE("Dynamic antidiag") {
 	SECTION("Vector") {
-		Matrix vec(4, 1, { 3,4,2,1 });
+		Matrix vec(4, 1, { 3, 4, 2, 1 });
 		auto mat = antidiag(vec);
 		REQUIRE(mat.rows() == 4);
 		REQUIRE(mat.cols() == 4);
@@ -199,7 +196,7 @@ TEST_CASE("Dynamic antidiag") {
 	}
 
 	SECTION("Initializer list") {
-		auto mat = antidiag({ 3,4,2,1 });
+		auto mat = antidiag({ 3, 4, 2, 1 });
 		REQUIRE(mat.rows() == 4);
 		REQUIRE(mat.cols() == 4);
 		REQUIRE(mat(3, 0) == 3);
@@ -335,8 +332,7 @@ TEST_CASE("MatrixViewConstructor") {
 	bool exceptionHappened{ false };
 	try {
 		Vector<float, 3> vec1{ mat.col(1) };
-	}
-	catch (Matrix_block_domain_error&) {
+	} catch (Matrix_block_domain_error&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened);
@@ -399,8 +395,7 @@ TEST_CASE("AtAccessOperatorBoundsException") {
 	bool exceptionHappened{ false };
 	try {
 		mat.at(3, 12);
-	}
-	catch (std::out_of_range&) {
+	} catch (std::out_of_range&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened == true);
@@ -439,11 +434,7 @@ TEST_CASE("ReverseIterator") {
 }
 
 TEST_CASE("ColIterator") {
-	Matrix<float, 3, 4> mat{
-		0, 3, 6, 9,
-		1, 4, 7, 10,
-		2, 5, 8, 11
-	};
+	Matrix<float, 3, 4> mat{ 0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11 };
 	float count = 0;
 	for (Index col = 0; col < mat.cols(); col++) {
 		for (auto it = mat.col_begin(col); it != mat.col_end(col); it++) {
@@ -453,11 +444,7 @@ TEST_CASE("ColIterator") {
 }
 
 TEST_CASE("RowIterator") {
-	Matrix<float, 3, 4> mat{
-		0, 1, 2, 3,
-		4, 5, 6, 7,
-		8, 9, 10, 11
-	};
+	Matrix<float, 3, 4> mat{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
 	float count = 0;
 	for (Index row = 0; row < mat.rows(); row++) {
 		for (auto it = mat.row_begin(row); it != mat.row_end(row); it++) {
@@ -667,7 +654,7 @@ TEST_CASE("MatrixView") {
 	Matrix<float, 4, 4> mat2(3);
 
 	mat1.block(1, 2, 2, 3) = mat2.block(1, 1, 2, 3);
-	std::cout << mat1 << "\n";
+	// std::cout << mat1 << "\n";
 	for (size_t i = 0; i < mat1.rows(); ++i) {
 		for (size_t j = 0; j < mat1.cols(); ++j) {
 			REQUIRE(mat1(i, j) == ((i > 0 && i < 3 && j > 1 && j < 5) ? 3.f : 1.f));
@@ -685,8 +672,8 @@ TEST_CASE("MatrixView") {
 	mat2.row(3) = mat2.row(2);
 
 
-	std::cout << mat1 << "\n";
-	std::cout << mat2 << "\n";
+	// std::cout << mat1 << "\n";
+	// std::cout << mat2 << "\n";
 }
 
 TEST_CASE("CopyBlockToMatrix") {
@@ -698,8 +685,7 @@ TEST_CASE("CopyBlockToMatrix") {
 	bool exceptionHappened{ false };
 	try {
 		mat2 = mat1.block(0, 0, 4, 3);
-	}
-	catch (std::exception&) {
+	} catch (std::exception&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened);
@@ -714,8 +700,7 @@ TEST_CASE("CopyMatrixToBlock") {
 	bool exceptionHappened{ false };
 	try {
 		mat.block(1, 0, 4, 4) = Matrix<float, 3, 3>::zero();
-	}
-	catch (std::exception&) {
+	} catch (std::exception&) {
 		exceptionHappened = true;
 	}
 	REQUIRE(exceptionHappened);
@@ -725,7 +710,16 @@ TEST_CASE("HadamardProduct") {
 	Matrix<int, 2, 3> mat1{ 1, 2, 3, 4, 5, 6 };
 	Matrix<int, 2, 3> mat2{ 23, -3, 4, 55, 622, 73 };
 	auto prod = hadamard(mat1, mat2);
-	for (auto it1 = mat1.begin(), it2 = mat2.begin(), it3 = prod.begin(); it1 != mat1.end(); ++it1, ++it2, ++it3) {
+	for (auto it1 = mat1.begin(), it2 = mat2.begin(), it3 = prod.begin(); it1 != mat1.end();
+		 ++it1, ++it2, ++it3)
+	{
 		REQUIRE((*it1) * (*it2) == *it3);
 	}
+}
+
+
+
+TEST_CASE("Format Matrix") {
+	Matrix<float, 1, 3> mat{ 3.2f, 3, 5 };
+	REQUIRE(fmt::format("{}", mat) == "| 3.2 3 5 |\n");
 }


### PR DESCRIPTION
This adds formatters for the types `qe::Binary`, `qe::BinaryPhase` and `qe::Matrix<T, m, n>`. 

All formatters are located in their own respective file, e.g., `format_binary.h`. This way, the formatters and thus `fmt/format.h` is not included by default when including any of these types. 

All math formatters can be included at once via `format_math.h`. 

Related: #7 